### PR TITLE
'ioctl' is replaced with 'nix' to fix the build of the 'rust-uinput' version 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords    = ["linux", "input"]
 
 [dependencies]
 libc  = "0.2"
-ioctl = "0.3"
+nix  = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 
 #[macro_use]
-extern crate ioctl;
+extern crate nix;
 
 use std::mem;
 
@@ -12,7 +12,7 @@ use libc::timeval;
 macro_rules! uin {
 	(write $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
 		pub unsafe fn $name(fd: c_int, val: $ty) -> c_int {
-			ioctl::ioctl(fd, iow!($ioty, $nr, mem::size_of::<$ty>()) as c_ulong, val)
+			libc::ioctl(fd, iow!($ioty, $nr, mem::size_of::<$ty>()) as c_ulong, val)
 		}
 	);
 }


### PR DESCRIPTION
Yanked 'iocrl' results in broken build of 'rust-uinput' version 0.1.2. This pull request together with [one created for 'rust-uinput'](https://github.com/meh/rust-uinput/pull/3) crate fixes the build.